### PR TITLE
Beta styling (for virtual conference)

### DIFF
--- a/layouts/_macros.html
+++ b/layouts/_macros.html
@@ -36,12 +36,12 @@
           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
           allowfullscreen>
   </iframe>
-  <iframe src="/slides/kervadec19.pdf"
+  <object data="{{ pdf_url }}"
           width="{{ width }}"
-          height="{{ height }}"
-          frameborder="0"
-          align="right">
-  </iframe>
+          height="{{ height }}">
+      <p>Your browser doesn't embed PDFs.
+         <a href="{{ pdf_url }}">Download slides.</a></p>
+  </object>
 {%- endmacro %}
 
 {% macro map(url, width=720, height=500) -%}

--- a/layouts/_macros.html
+++ b/layouts/_macros.html
@@ -1,6 +1,6 @@
-{% macro paper(title, authors, abstract=none, paper=none, openreview=none, video=none, code=none) -%}
+{% macro paper(title, authors, abstract=none, paper=none, openreview=none, video=none, code=none, id=none) -%}
 * <span class="title">
-    {% if paper %}<a href="{{ paper }}">{{ title }}</a>{% else %}{{ title }}{% endif %}
+    {% if id %}{{ id }} - {% endif -%}{% if paper %}<a href="{{ paper }}">{{ title }}</a>{% else %}{{ title }}{% endif %}
   </span>
   <span class="authors"> {{ authors }}</span>
   <ul class="links">

--- a/layouts/_macros.html
+++ b/layouts/_macros.html
@@ -28,6 +28,22 @@
 </div>
 {%- endmacro %}
 
+{% macro presentation(youtube_id, pdf_url, width=720, height=405) -%}
+  <iframe width="{{ width }}"
+          height="{{ height }}"
+          src="https://www.youtube-nocookie.com/embed/{{ youtube_id }}"
+          frameborder="0"
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen>
+  </iframe>
+  <iframe src="/slides/kervadec19.pdf"
+          width="{{ width }}"
+          height="{{ height }}"
+          frameborder="0"
+          align="right">
+  </iframe>
+{%- endmacro %}
+
 {% macro map(url, width=720, height=500) -%}
 <div class="google-maps">
     <iframe src="{{ url }}"

--- a/stylesheets/_page.scss
+++ b/stylesheets/_page.scss
@@ -587,4 +587,45 @@ iframe[src*="youtube"] {
   }
 }
 
+&.paper-page {
+  .paper_abstract {
+    display: none;
+    font-size: 90%;
+    line-height: 1.35;
+    text-align: justify;
+    margin-top: 4px;
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-bottom: 4px;
+
+    .actions {
+      display: block;
+      text-align: center;
+      margin-top: 4px;
+    }
+  }
+  .paper_qa {
+    display: none;
+    line-height: 1.35;
+    text-align: center;
+    margin-top: 4px;
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-bottom: 4px;
+
+    .actions {
+      display: block;
+      text-align: center;
+      margin-top: 4px;
+    }
+  }
+  h2, h3 {
+    font-family: 'Lato', 'Trebuchet MS', sans-serif;
+    text-align: center;
+    font-weight: normal;
+    margin-top: 26px;
+    margin-bottom: 13px;
+    line-height: 1.2;
+  }
+}
 @import 'footer';


### PR DESCRIPTION
Several changes in the style, some of them visible at https://beta.2020.midl.io . I think that for once, I managed to separate the commits by topic.

The [paper template](https://github.com/MIDL-Conference/midl-website-2020/blob/beta/pages/program/papers/paper.template) is not fully satisfactory now, but as the paper pages are still evolving it is not worth it to refactor that now.