### PR TITLE
Keywords for paper list ; teaser macro

### DIFF
--- a/layouts/_macros.html
+++ b/layouts/_macros.html
@@ -1,13 +1,15 @@
-{% macro paper(title, authors, abstract=none, paper=none, openreview=none, video=none, code=none, id=none) -%}
+{% macro paper(title, authors, abstract=none, paper=none, openreview=none, video=none, code=none, id=none, teaser=none, pdf=none) -%}
 * <span class="title">
     {% if id %}{{ id }} - {% endif -%}{% if paper %}<a href="{{ paper }}">{{ title }}</a>{% else %}{{ title }}{% endif %}
   </span>
   <span class="authors"> {{ authors }}</span>
   <ul class="links">
     {% if abstract %}<li><a class="toggle_visibility" data-selector=".abstract" data-level="3">abstract</a></li>{% endif -%}
+    {% if pdf %}<li><a href="{{ pdf }}">paper</a></li>{% endif -%}
     {% if openreview %}<li><a href="{{ openreview }}">reviews</a></li>{% endif -%}
     {% if code %}<li><a href="{{ code }}">code</a></li>{% endif -%}
     {% if video %}<li><a href="{{ video }}">video</a></li>{% endif -%}
+    {% if teaser %}<li><a href="{{ teaser }}">teaser</a></li>{% endif -%}
   </ul>
   {%- if abstract -%}
   <span class="abstract">

--- a/layouts/_macros.html
+++ b/layouts/_macros.html
@@ -75,3 +75,8 @@
   <meta property="og:{{ name|e }}" content="{% if prefix %}{{ prefix|e }}{% endif %}{{ content|e }}">
   {%- endif -%}
 {%- endmacro -%}
+
+
+{% macro teaser(id) -%}
+  {% if id %} - <a href="https://youtu.be/{{ id }}">Teaser</a>{% endif %}
+{%- endmacro %}


### PR DESCRIPTION
Two small changes:


## More keywords for the paper list:
![Screenshot_2020-06-30 MIDL 2020 Tentative Program - Long - MIDL 2020(1)](https://user-images.githubusercontent.com/4191866/86249129-d6110580-bb7c-11ea-8fec-969dad01156a.png)
Since now the `paper` param leads to a dedicated page (and not the pdf), I had to add a `pdf` argument. Also, we now have an optional teaser for the videos.

## Switch to display de teaser button in the dedicated page, IF there is a teaser