### PR TITLE
Add two new macros for embedded html videos

### DIFF
--- a/layouts/_macros.html
+++ b/layouts/_macros.html
@@ -45,6 +45,26 @@
 <p class="centered"><a href="{{ pdf_url }}">Download slides</a></p>
 {%- endmacro %}
 
+{% macro video(video_url, width=720, height=405) -%}
+<div>
+  <video width="{{ width }}" height="{{ height }}" controls>
+    <source src="{{ video_url }}" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
+</div>
+{%- endmacro %}
+
+
+{% macro html_presentation(youtube_id, pdf_url, width=720, height=405) -%}
+{{ video(youtube_id) }}
+
+<object data="{{ pdf_url }}"
+        width="{{ width }}"
+        height="{{ height }}" class="embedded-pdf">
+  Can't display slides, your browser doesn't support embedding PDFs. You can still download the slides:
+</object>
+{%- endmacro %}
+
 {% macro map(url, width=720, height=500) -%}
 <div class="google-maps">
     <iframe src="{{ url }}"


### PR DESCRIPTION
Heavily inspired from the old macro that used youtube as video delivery.