### PR TITLE
Add (missing) "download slides" link into html and cloudflare present…

### DIFF
--- a/layouts/_macros.html
+++ b/layouts/_macros.html
@@ -62,6 +62,8 @@
         height="{{ height }}" class="embedded-pdf">
   Can't display slides, your browser doesn't support embedding PDFs.
 </object>
+
+<p class="centered"><a href="{{ pdf_url }}">Download slides</a></p>
 {%- endmacro %}
 
 {% macro cloudflare_video(video_id, width=720, height=405) -%}
@@ -82,6 +84,8 @@
         height="{{ height }}" class="embedded-pdf">
   Can't display slides, your browser doesn't support embedding PDFs.
 </object>
+
+<p class="centered"><a href="{{ pdf_url }}">Download slides</a></p>
 {%- endmacro %}
 
 


### PR DESCRIPTION
…ations macros.

This is useful to link directly to the slides, or easily maximize some slides (especially A0 posters).

This was in the original `presentation` macro, but since I am an idiot, I did not copy and paste correctly that part.