### PR TITLE
css for abstract class (for the "paper" macro, used in the program)

### DIFF
--- a/stylesheets/_page.scss
+++ b/stylesheets/_page.scss
@@ -336,6 +336,12 @@ iframe[src*="youtube"] {
   border: 1px solid #F0F0F0;
 }
 
+.abstract {
+  text-align: justify;
+  text-justify: auto;
+  hyphens: auto;
+}
+
 .newsletter-signup-form {
   width: 420px;
   margin: 40px auto 0 auto;

--- a/stylesheets/default.scss
+++ b/stylesheets/default.scss
@@ -31,12 +31,6 @@ body {
     min-height: 100vh;
     justify-content: center;
   }
-
-  .abstract {
-    text-align: justify;
-    text-justify: auto;
-    hyphens: auto;
-  }
 }
 
 #sidebar {

--- a/stylesheets/default.scss
+++ b/stylesheets/default.scss
@@ -31,6 +31,12 @@ body {
     min-height: 100vh;
     justify-content: center;
   }
+
+  .abstract {
+    text-align: justify;
+    text-justify: auto;
+    hyphens: auto;
+  }
 }
 
 #sidebar {


### PR DESCRIPTION
The motivation is to have a proper justification, with hyphenation and line breaks where needed, when displaying the abstract. 

I do believe it is more pleasant to the eyes, and makes the whole more consistent with a LaTeX abstract. See the screenshot:
![Screenshot_2021-09-01 MIDL 2021(2)](https://user-images.githubusercontent.com/4191866/131771637-89f910b6-9fed-41a0-ac9a-1dcda0356558.png)



I am not 100% where that code tidbit should go, but I tried not to make it global. Putting it into the theme directly will make it available for futures MIDL editions.
